### PR TITLE
Ready for new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ and options are:
 + nodata: If `nodata` is specified, cache will save all command returns, but will not save data if any changes in data are detected.  
 + datacheck(string): Allows for data on disk to be checked to ensure command uniqueness.
 + framecheck(string): Allows for additional frames to be checked to ensure command uniqueness.
-+ clear: Allows command implementation to proceed even if this would unsaved changes in data (similar, for example, to `use, clear`) 
++ clear: Allows command implementation to proceed even if this would unsaved changes in data (similar, for example, to `use, clear`)
++ hidden: Instead of returning hidden elements as visible stored results re-hides any hidden elements.
 + replace: Forces cache to re-run the command and re-cache results, even if a previously cached version of command output has been found.  Such an example may be useful if commands are re-issued and command behaviour has changed.
 + keepall: Indicates that elements stored by previous commands in e(return) and s(return) lists should not be cleared prior to invoking the command requested with cache, allowing for their future use.
 

--- a/cache.ado
+++ b/cache.ado
@@ -218,9 +218,14 @@ program define cache, rclass properties(prefix)
 	// Find graphs --------------------------
 	local gfiles: dir "`dir'" files "`call_hash'*.gph", respectcase
 
+	// If hide is specified, re-run first time even if run previously
+	local newhide = 0
 	if "`hidden'"!="" {
 		cap findfile `call_hash'_elements.dta, path(`dir')
-		if _rc!=0 local force force
+		if _rc!=0 {
+			local force force
+			local newhide = 1
+		}
 	}
 
  	if (length(`"`files'"') != 0 | length(`"`gfiles'"') != 0) & "`force'"=="" {
@@ -501,7 +506,12 @@ program define cache, rclass properties(prefix)
 	if "`hidden'"!="" qui log using "`dir'/rlist.txt", name(rlog) text replace
 	* Now, run the command on the right
 	capture noisily `right'
-	if "`hidden'"!="" return list
+	if "`hidden'"!="" {
+		dis ""
+		dis "The following elements will be returned as visible"
+		return list
+
+	}
 
 	// If requires clear, add if clear argument is provided
 	if _rc==4 & ("`clear'"=="clear") {
@@ -639,6 +649,9 @@ program define cache, rclass properties(prefix)
 		frame drop ``n'_results'
 	}
 	qui log close `logfile'
+	if `newhide'==1 {
+		cache_cleanlog, folder("`dir'") fname("`call_hash'")
+	}
 
 	//========================================================
 	// Store results (data) 
@@ -798,6 +811,23 @@ program define cache_setdir, rclass
 	return local dir = "`dir'"
 end
 
+// Clean log
+cap program drop cache_cleanlog
+program define cache_cleanlog, rclass
+	syntax [anything], folder(string) fname(string)
+
+	file open writelog using "`folder'/mostrecentcache.smcl", write text replace
+	file open readlog using "`folder'/`fname'.smcl", read text
+	file read readlog line
+	while regexm("`line'", "The following elements will be returned")!=1 {
+		file write writelog "`line'" _newline
+		file read readlog line
+	}
+	file close readlog
+	file close writelog
+	copy "`folder'/mostrecentcache.smcl" "`folder'/`fname'.smcl", replace
+end
+
 // Unpack saved file name like e_scalars, or r_matrix_PT
 cap program drop cache_parsefile
 program define cache_parsefile, rclass
@@ -860,7 +890,7 @@ exit
 ><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><
 
 Notes:
-1. Could build in temporary caching (eg only while session lasts, using tempfiles or frames instead of dtas) -- note that this could be done by using tempdir
+1. Update log to remove the return if hidden specified 
 
 Version Control:
 

--- a/cache.ado
+++ b/cache.ado
@@ -25,7 +25,7 @@ program define cache, rclass properties(prefix)
 		syntax [anything(name=subcmd)], [dir(string) project(string) *]
 
 		if ("`dir'" == "") {
-			cache_setdir
+			qui cache_setdir
 			local dir = "`r(dir)'"
 		}
 		if ("`project'" != "") {
@@ -43,7 +43,7 @@ program define cache, rclass properties(prefix)
 		syntax [anything(name=subcmd)], [dir(string) project(string) *]
 
 		if ("`dir'" == "") {
-			cache_setdir
+			qui cache_setdir
 			local dir = "`r(dir)'"
 		}
 		if ("`project'" != "") {
@@ -95,6 +95,8 @@ program define cache, rclass properties(prefix)
 		project(string)          ///  
 		prefix(string)           /// 
 		noDATA                   /// 
+		datacheck(string)        ///  
+		framecheck(string)       /// 
 		pause                    ///
 		KEEPall                  ///  does not clear previous returns  
 		clear                    ///  
@@ -114,7 +116,7 @@ program define cache, rclass properties(prefix)
 
 	// Set dir if not selected by user
 	if ("`dir'" == "") {
-		cache_setdir
+		qui cache_setdir
 		local dir = "`r(dir)'"
 	}
 	else {
@@ -150,6 +152,46 @@ program define cache, rclass properties(prefix)
 	local datasignature = "`r(datasignature)'"
 	return local datasignature = "`datasignature'"
 	
+	//  Incorporate additional data -------------------------
+	if (`"`datacheck'"' != "") {
+		tokenize `"`datacheck'"'
+
+		//dsignatures will hold data signatures of all added datasets
+		local dsignatures
+		preserve
+		while `"`1'"' != "" {
+			qui use `"`1'"'
+
+			qui datasignature 
+			local dsig = "`r(datasignature)'"
+			local dsignatures = "`dsignatures'_`dsig'"
+
+			macro shift
+		}
+		restore
+		return local datasignature = "`datasignature'`dsignatures'"
+	}
+
+	//  Incorporate additional frames -----------------------
+	if ("`framecheck'" != "") {
+		tokenize `"`framecheck'"'
+
+		//fsignatures will hold data signatures of all added frames
+		local fsignatures
+		qui pwf
+		local cframe = r(currentframe)
+		while `"`1'"' != "" {
+			cwf `1'
+			qui datasignature 
+			local fsig = "`r(datasignature)'"
+			local fsignatures = "`fsignatures'_`fsig'"
+
+			macro shift
+		}
+		cwf `cframe'
+		return local datasignature = "`datasignature'`fsignatures'"
+	}
+
 	//  combine both parts --------------------------
 	cache_hash get,  cmd_call("`cmd_hash'`datasignature'") prefix("`prefix'")
 	local call_hash = "`r(chhash)'"
@@ -533,7 +575,7 @@ program define cache, rclass properties(prefix)
 	foreach f of local finalframes {
 		if `"`f'"'=="default" continue
 
-		local framecheck = 0
+		local framescheck = 0
 		foreach oframe of local allframes {
 			if "`f'"=="`oframe'" {
 				// dis "Frame `f' existed previously" (check if changed)
@@ -544,11 +586,11 @@ program define cache, rclass properties(prefix)
 					frame `f': qui describe
 					if r(k) > 0 local saveframes = "`saveframes' `f'"
 				}
-				local framecheck = 1
+				local framescheck = 1
 				continue, break
 			}
 		}
-		if `framecheck'==0 {
+		if `framescheck'==0 {
 			frame `f': qui describe
 			if r(k) > 0 local saveframes = "`saveframes' `f'"
 		}
@@ -557,7 +599,7 @@ program define cache, rclass properties(prefix)
 		//dis "Saving frames: `saveframes'"
 		qui frames save "`dir'/`call_hash'.dtas", frames(`saveframes') replace
 	}
-        }
+	}
 
 	//========================================================
 	// Store results (graphs) 

--- a/cache.ado
+++ b/cache.ado
@@ -81,7 +81,6 @@ program define cache, rclass properties(prefix)
 	}
 	local cmd_properties : results `cmd'
 	local cmd_results : results `cmd'
-
 	local origframe = c(frame)
 
 	//========================================================
@@ -221,6 +220,22 @@ program define cache, rclass properties(prefix)
 
  	if (length(`"`files'"') != 0 | length(`"`gfiles'"') != 0) & "`force'"=="" {
 		//dis "Cache found"
+		// Test for hash collision
+		tempname hashcheck
+		frame create `hashcheck'
+		cwf `hashcheck'
+		qui use "`dir'/`call_hash'_r_macros.dta", clear
+		qui count
+		local rnmax=r(N)
+		local matchedCommand = contents[`rnmax']
+		if "`matchedCommand'" != "`right'" {
+			dis "{err: Hash collision detected.}"
+			dis "{err: This is a very rare occurrence in which an identical hash has coincidentally been generated for two distinct strings.}"
+			dis "{err: You typed `matchedCommand'.}"
+			dis "{err: This matched with `right'.}"
+			dis "{err: Please slightly change your syntax of the typed command, which will result in a different hash.}"
+			exit 693
+		}
 
 		// Generate frames to load returns
 		foreach n in scalars macros matrices {
@@ -280,7 +295,7 @@ program define cache, rclass properties(prefix)
 					// Otherwise, remove this else if condition
 				}
 			}
-		}	
+		}
 
 		//========================================================
 		// Export matrices and ereturn post
@@ -322,7 +337,6 @@ program define cache, rclass properties(prefix)
 			cwf	`origframe'
 		}
 
-
 		//========================================================
 		// Export scalars and macros
 		//========================================================
@@ -345,6 +359,7 @@ program define cache, rclass properties(prefix)
 				clear
 				//Import scalar or macro file
 				use "`dir'/`call_hash'`rfile_name'", clear
+
 				qui count
 				if r(N)==0 continue 
 				foreach num of numlist 1(1)`r(N)' {
@@ -352,7 +367,7 @@ program define cache, rclass properties(prefix)
 					local contents = contents[`num']
 					// Return this element
 					if "`type'"=="macros"  {
-						if "`first_letter'"=="r" cap return local item = `contents'
+						if "`first_letter'"=="r" return local `item' `"`contents'"'
 						else cache_`treturn' "`contents'", name(`item') type("local")
 					}
 					else if "`type'"=="scalars" {
@@ -556,6 +571,25 @@ program define cache, rclass properties(prefix)
 	}
 	return add // add results of cmd
 	if `dtasave'==1 cap drop _funcvar
+
+	// Add cached command as r macro.  This allows for check of hash collision
+	cwf `scalars_results'
+	clear
+	cap use "`dir'/`call_hash'_r_macros.dta", clear
+	if _rc==0 {
+		qui count
+		local rn1 = r(N)+1
+		qui set obs `rn1'
+		qui replace item = "cached_command" in `rn1'
+		qui replace contents = "`right'" in `rn1'
+	}
+	else {
+		qui set obs 1
+		qui gen item = "cached_command"
+		qui gen contents = "`right'"
+	}
+	qui save "`dir'/`call_hash'_r_macros.dta", replace
+	cwf `origframe'
 
 	foreach n in scalars macros matrices {
 		frame drop ``n'_results'

--- a/cache.ado
+++ b/cache.ado
@@ -169,6 +169,7 @@ program define cache, rclass properties(prefix)
 			macro shift
 		}
 		restore
+		local datasignature = "`datasignature'`dsignatures'"
 		return local datasignature = "`datasignature'`dsignatures'"
 	}
 
@@ -189,6 +190,7 @@ program define cache, rclass properties(prefix)
 			macro shift
 		}
 		cwf `cframe'
+		local datasignature = "`datasignature'`fsignatures'"
 		return local datasignature = "`datasignature'`fsignatures'"
 	}
 
@@ -298,6 +300,7 @@ program define cache, rclass properties(prefix)
 						cwf	`origframe'
 						qui use "`dir'/`call_hash'", clear
 						ereturn post b V, esample(_funcvar) 
+						local loadfiles = 0
 					}
 					else {
 						ereturn post b V
@@ -360,6 +363,7 @@ program define cache, rclass properties(prefix)
 			}
 		}
 		cwf	`origframe'
+		if `loadfiles' == 1 qui use "`dir'/`call_hash'", clear
 		if `loadframes'==1 qui frames use "`dir'/`call_hash'.dtas", `clear' replace
 
 
@@ -397,7 +401,13 @@ program define cache, rclass properties(prefix)
 	// save signatures of each
 	foreach f of local allframes {
 		frame `f': qui datasignature
-		local sig_`f' = "`r(datasignature)'"
+
+		// Work with edge case: frames of 31 or 32 characters
+		if length("`f'")>30 {
+			mata: st_local("fname", strofreal(hash1("`f'", ., 2), "%12.0gc"))
+		}
+		else local fname = "`f'"
+		local s`fname' = "`r(datasignature)'"
 	}
 
 	// Save baseline graphs before running command
@@ -555,50 +565,57 @@ program define cache, rclass properties(prefix)
 	//========================================================
 	// Store results (data) 
 	//========================================================
-        if "`data'"=="" { 
+    if "`data'"=="" { 
         qui datasignature 
-	local datasignature2 = "`r(datasignature)'"
-	if ("`datasignature'" != "`datasignature2'") & `dtasave'==0 {
-		//dis "Data has changed, saving data"
-		qui save "`dir'/`call_hash'.dta", replace
-	}
+		local datasignature2 = "`r(datasignature)'"
+		if ("`datasignature'" != "`datasignature2'") & `dtasave'==0 {
+			//dis "Data has changed, saving data"
+			qui save "`dir'/`call_hash'.dta", replace
+		}
 
-	//========================================================
-	// Store results (frames) 
-	//========================================================
-	// data frame ----------
-	// if the the cmd returns or changes a data frame, save it
-	qui frames dir
-	local finalframes = r(frames)
-	local saveframes 
+		//========================================================
+		// Store results (frames) 
+		//========================================================
+		// data frame ----------
+		// if the the cmd returns or changes a data frame, save it
+		qui frames dir
+		local finalframes = r(frames)
+		local saveframes 
 
-	foreach f of local finalframes {
-		if `"`f'"'=="default" continue
+		foreach f of local finalframes {
+			if `"`f'"'=="default" continue
 
-		local framescheck = 0
-		foreach oframe of local allframes {
-			if "`f'"=="`oframe'" {
-				// dis "Frame `f' existed previously" (check if changed)
-				frame `f': qui datasignature
-				local signew_`f' = "`r(datasignature)'"
-				// test if signature has changed, and if so add to save list
-				if "`signew_`f''" != "`sig_`f''" {
-					frame `f': qui describe
-					if r(k) > 0 local saveframes = "`saveframes' `f'"
+			local framescheck = 0
+			foreach oframe of local allframes {
+				if "`f'"=="`oframe'" {
+					// dis "Frame `f' existed previously" (check if changed)
+					frame `f': qui datasignature
+
+					// Work with edge case: frames of 31 or 32 characters
+					if length("`f'")>30 {
+						mata: st_local("fname", strofreal(hash1("`f'", ., 2), "%12.0gc"))
+					}
+					else local fname = "`f'"
+
+					local t`fname' = "`r(datasignature)'"
+					// test if signature has changed, and if so add to save list
+					if "`t`fname''" != "`s`fname''" {
+						frame `f': qui describe
+						if r(k) > 0 local saveframes = "`saveframes' `f'"
+					}
+					local framescheck = 1
+					continue, break
 				}
-				local framescheck = 1
-				continue, break
+			}
+			if `framescheck'==0 {
+				frame `f': qui describe
+				if r(k) > 0 local saveframes = "`saveframes' `f'"
 			}
 		}
-		if `framescheck'==0 {
-			frame `f': qui describe
-			if r(k) > 0 local saveframes = "`saveframes' `f'"
+		if "`saveframes'" != "" {
+			//dis "Saving frames: `saveframes'"
+			qui frames save "`dir'/`call_hash'.dtas", frames(`saveframes') replace
 		}
-	}
-	if "`saveframes'" != "" {
-		//dis "Saving frames: `saveframes'"
-		qui frames save "`dir'/`call_hash'.dtas", frames(`saveframes') replace
-	}
 	}
 
 	//========================================================

--- a/cache.ado
+++ b/cache.ado
@@ -98,6 +98,7 @@ program define cache, rclass properties(prefix)
 		framecheck(string)       /// 
 		pause                    ///
 		KEEPall                  ///  does not clear previous returns  
+		hidden                   ///  keeps hidden returns hidden
 		clear                    ///  
 		replace                  ///  check if this does something else
 		force                    ///  force says to re-run even if the cache is there
@@ -217,6 +218,10 @@ program define cache, rclass properties(prefix)
 	// Find graphs --------------------------
 	local gfiles: dir "`dir'" files "`call_hash'*.gph", respectcase
 
+	if "`hidden'"!="" {
+		cap findfile `call_hash'_elements.dta, path(`dir')
+		if _rc!=0 local force force
+	}
 
  	if (length(`"`files'"') != 0 | length(`"`gfiles'"') != 0) & "`force'"=="" {
 		//dis "Cache found"
@@ -235,6 +240,17 @@ program define cache, rclass properties(prefix)
 			dis "{err: This matched with `right'.}"
 			dis "{err: Please slightly change your syntax of the typed command, which will result in a different hash.}"
 			exit 693
+		}
+
+		// Open all elements of visible returns
+		local elfn
+		if "`hidden'"!="" {
+			tempname elements
+			frame create `elements'
+			frame `elements' {
+				use "`dir'/`call_hash'_elements.dta", clear
+			}
+			local elfn elframe(`elements')
 		}
 
 		// Generate frames to load returns
@@ -326,13 +342,21 @@ program define cache, rclass properties(prefix)
 			foreach matrix of local ematrix {
 				cwf	`matrices_results'
 				if !inlist("`matrix'", "b", "V", "Cns") {
-					cache_ereturn `matrix', name(`matrix') type("matrix")
+					cache_ereturn `matrix', name(`matrix') type("matrix") `hidden' `elfn'
 				}
 			}
 			// Return rmatrices
 			foreach matrix of local rmatrix {
 				cwf	`matrices_results'
-				return matrix `matrix'=`matrix' 
+				if "`hidden'"!="" {					
+					frame `elements' {
+						qui count if regexm(element, "r\(`matrix'\)")==1
+						if r(N)==1 local hh "visible"
+						if r(N)==0 local hh "hidden"
+					}
+					return `hh' matrix `matrix'=`matrix' 
+				}
+				else return matrix `matrix'=`matrix'
 			}
 			cwf	`origframe'
 		}
@@ -367,12 +391,32 @@ program define cache, rclass properties(prefix)
 					local contents = contents[`num']
 					// Return this element
 					if "`type'"=="macros"  {
-						if "`first_letter'"=="r" return local `item' `"`contents'"'
-						else cache_`treturn' "`contents'", name(`item') type("local")
+						if "`first_letter'"=="r" {
+							if "`hidden'"!="" {					
+								frame `elements' {
+									qui count if regexm(element, "r\(`item'\)")==1
+									if r(N)==1 local hh "visible"
+									if r(N)==0 local hh "hidden"
+								}
+								return `hh' local `item' `"`contents'"'
+							}
+							else return local `item' `"`contents'"'
+						}
+						else cache_`treturn' "`contents'", name(`item') type("local") `hidden' `elfn'
 					}
 					else if "`type'"=="scalars" {
-						if "`first_letter'"=="r" return scalar `item' = `contents'
-						else cache_`treturn' `contents', name(`item') type("scalar")
+						if "`first_letter'"=="r" {
+							if "`hidden'"!="" {					
+								frame `elements' {
+									qui count if regexm(element, "r\(`item'\)")==1
+									if r(N)==1 local hh "visible"
+									if r(N)==0 local hh "hidden"
+								}
+								return `hh' scalar `item' = `contents'
+							}
+							else return scalar `item' = `contents'
+						}
+						else cache_`treturn' `contents', name(`item') type("scalar") `hidden' `elfn'
 					}
 				}
 			}
@@ -380,7 +424,6 @@ program define cache, rclass properties(prefix)
 		cwf	`origframe'
 		if `loadfiles' == 1 qui use "`dir'/`call_hash'", clear
 		if `loadframes'==1 qui frames use "`dir'/`call_hash'.dtas", `clear' replace
-
 
 		//========================================================
 		// Export graphs and store in memory
@@ -394,7 +437,6 @@ program define cache, rclass properties(prefix)
 		}
 
 
-
 		//========================================================
 		// Print command output
 		//========================================================
@@ -402,6 +444,7 @@ program define cache, rclass properties(prefix)
 			dis "{res}Command was cached.  Recovering previous output."
 			type "`log'"
 		}	
+		if "`hidden'"!="" frame drop `elements'
 		exit
 	}
 
@@ -454,8 +497,12 @@ program define cache, rclass properties(prefix)
  	file close cachedcommands 
 
 
+	// Will log for return list, ereturn list and sreturn list to check for hidden returns
+	if "`hidden'"!="" qui log using "`dir'/rlist.txt", name(rlog) text replace
 	* Now, run the command on the right
 	capture noisily `right'
+	if "`hidden'"!="" return list
+
 	// If requires clear, add if clear argument is provided
 	if _rc==4 & ("`clear'"=="clear") {
 		// At present, a small bug. 
@@ -470,9 +517,6 @@ program define cache, rclass properties(prefix)
 	}
 
 	local dtasave   = 0
-	//========================================================
-	// Store results (lists)
-	//========================================================
 
 	// ret list --------------
 	local classes = "r e s"
@@ -689,6 +733,40 @@ program define cache, rclass properties(prefix)
 		graph drop `defaultgraph'
 	}
 
+	if "`hidden'"!="" {
+		//========================================================
+		// Store results (lists)
+		//========================================================
+		qui log close rlog
+		qui log using "`dir'/elist.txt", name(elog) text replace
+		ereturn list
+		qui log close elog
+		qui log using "`dir'/slist.txt", name(slog) text replace
+		sreturn list
+		qui log close slog
+
+		//========================================================
+		// Generate list of observed elements
+		//========================================================
+		tempname observed_elements
+		frame create `observed_elements'
+		cwf `observed_elements'
+		gen element = ""
+		qui save "`dir'/`call_hash'_elements.dta", replace
+		foreach etype in r e s {
+			qui {
+				import delimited using "`dir'/`etype'list.txt", clear
+				cap gen v1 = ""
+				gen element = regexs(0) if regexm(v1,"`etype'\([^)]+\)")
+				drop if missing(element)
+				keep element
+				append using "`dir'/`call_hash'_elements.dta"
+				qui save "`dir'/`call_hash'_elements.dta", replace
+			}
+		}
+		cwf `origframe'
+		frame drop `observed_elements'
+	}
 end
 
 //========================================================
@@ -741,22 +819,38 @@ end
 // ereturn program
 cap program drop cache_ereturn
 program define cache_ereturn, eclass
-	syntax anything(name=element), name(string) type(string)
-	ereturn `type' `name' = `element'
+	syntax anything(name=element), name(string) type(string) [hidden elframe(string)]
+	if "`hidden'"!="" {
+		frame `elframe' {
+			qui count if regexm(element, "e\(`name'\)")==1
+			if r(N)==1 local hh "visible"
+			if r(N)==0 local hh "hidden"
+		}
+	}
+	else local hh "visible"
+
+	ereturn `hh' `type' `name' = `element'
 end
 
 // sreturn program
 cap program drop cache_sreturn
 program define cache_sreturn, sclass
-	syntax anything(name=element), name(string) type(string)
+	syntax anything(name=element), name(string) type(string) [hidden elframe(string)]
 	sreturn `type' `name'=`element'
 end
 
-// return program (could be removed if desired as cache is r-class)
+// return program
 cap program drop cache_return
 program define cache_return, rclass
 	syntax anything(name=element), name(string) type(string)
-	return `type' `name'=`element'
+
+	frame elements {
+		qui count if regexm(element, "r\(`name'\)")==1
+		if r(N)==1 local hh "visible"
+		if r(N)==0 local hh "hidden"
+	}
+
+	return `hh' `type' `name'=`element'
 end
 
 

--- a/cache.sthlp
+++ b/cache.sthlp
@@ -47,6 +47,7 @@
 {synopt :{opt datacheck(string)}}Allows for data on disk to be checked to ensure command uniqueness{p_end}
 {synopt :{opt framecheck(string)}}Allows for additional frames to be checked to ensure command uniqueness{p_end}
 {synopt :{opt clear}}Allows command to proceed even if this saves over data currently in memory{p_end}
+{synopt :{opt hidden}}Does not return hidden elements as visible stored results{p_end}
 {synopt :{opt replace}}Re-runs command and saves over previously cached version{p_end}
 {synopt :{opt keep:all}}Does not clear previous ereturn and sreturn lists, permitting future use{p_end}
 {synoptline}
@@ -173,6 +174,16 @@ in {opt framecheck} as desired, and the name of each frame should simply be sepa
 {phang}
 {opt clear} Allows command implementation to proceed even if this would unsaved changes in 
 data (similar, for example, to {it: use, clear})
+
+{phang}
+{opt hidden} By default {cmd:cache} returns all stored results, including hidden results as standard 
+stored results, and so hidden results will be visible following {cmd: cache}.  If you would like hidden  
+elements to stay hidden, the {opt hidden} option should be specified.
+ See
+{mansection P returnRemarksandexamplesUsinghiddenandhistoricalstoredresults:{it:Using hidden and historical stored results}}
+and
+{mansection P returnRemarksandexamplesProgramminghiddenandhistoricalstoredresults:{it:Programming hidden and historical stored results}}
+under {it:Remarks and examples} of {bf:[P] return} for more information. 
 
 {phang}
 {opt replace} Forces {cmd:cache} to re-run the command and re-cache results, even if a 

--- a/cache.sthlp
+++ b/cache.sthlp
@@ -156,13 +156,13 @@ as the use of e(sample) will not be available.
 output and results will be returned, but updates to data will not be produced.
 
 {phang}
-{opt datacheck(string)} By default {cmd:cache} tests data in memory and the command syntex,
+{opt datacheck(string)} By default {cmd:cache} tests data in memory and the command syntax,
 and determines that a command has been cached if data in memory is identical and the command as
 typed is identical.  However, at times external data files may be called which have identical names,
 but altered contents.  In cases such as this, {opt datacheck} can be used to indicate that {cmd:cache}
 should also ensure that any external data files necessary for the command are also included when 
-testing storing a unique command identifier, or checking whether an identical command has previously
-been hashed.  As many data files can be indicated in {opt datacheck} as required, and the name of each
+generating a unique command identifier, or checking whether an identical command has previously
+been cached.  As many data files can be indicated in {opt datacheck} as desired, and the name of each
 Stata data file should simply be separated by white space.
 
 {phang}

--- a/cache.sthlp
+++ b/cache.sthlp
@@ -43,8 +43,10 @@
   if further organisation of cached commands is desired{p_end}
 {synopt :{opt prefix(string)}}Defines a prefix for all saved elements of a command; 
   default is _ch{p_end}
-{synopt :{opt nodata}}does not cache data if changes occur in data{p_end}
-{synopt :{opt clear}}allows command to proceed even if this saves over data currently in memory{p_end}
+{synopt :{opt nodata}}Does not cache data if changes occur in data{p_end}
+{synopt :{opt datacheck(string)}}Allows for data on disk to be checked to ensure command uniqueness{p_end}
+{synopt :{opt framecheck(string)}}Allows for additional frames to be checked to ensure command uniqueness{p_end}
+{synopt :{opt clear}}Allows command to proceed even if this saves over data currently in memory{p_end}
 {synopt :{opt replace}}Re-runs command and saves over previously cached version{p_end}
 {synopt :{opt keep:all}}Does not clear previous ereturn and sreturn lists, permitting future use{p_end}
 {synoptline}
@@ -152,6 +154,21 @@ as the use of e(sample) will not be available.
 
 {pmore} This option should be used with care, as in future calls to {cmd:cache} all command
 output and results will be returned, but updates to data will not be produced.
+
+{phang}
+{opt datacheck(string)} By default {cmd:cache} tests data in memory and the command syntex,
+and determines that a command has been cached if data in memory is identical and the command as
+typed is identical.  However, at times external data files may be called which have identical names,
+but altered contents.  In cases such as this, {opt datacheck} can be used to indicate that {cmd:cache}
+should also ensure that any external data files necessary for the command are also included when 
+testing storing a unique command identifier, or checking whether an identical command has previously
+been hashed.  As many data files can be indicated in {opt datacheck} as required, and the name of each
+Stata data file should simply be separated by white space.
+
+{phang}
+{opt framecheck(string)} Allows for identical behaviour as in {opt datacheck}, but now by testing
+the precise contents of any frames indicated in {opt framecheck}.  As many frames can be indicated 
+in {opt framecheck} as desired, and the name of each frame should simply be separated by white space.
 
 {phang}
 {opt clear} Allows command implementation to proceed even if this would unsaved changes in 


### PR DESCRIPTION
This has corrected return lists in commands with ereturn and return.  It also provides an option to "rehide" elements which were previously hidden but "unhidden" because of cache.  It also incorporates framecheck and datacheck to allow for checks to external data which may have changed.   Documentation is now up to date on github, sthlp and overleaf.